### PR TITLE
Add TLS support, improve Cadet.before(), add convenience template function

### DIFF
--- a/cadet.lua
+++ b/cadet.lua
@@ -30,10 +30,13 @@
   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ]]
 
+-- httpd interface
+local httpd = require "httpd"
+
 -- The main namespace.
 local Cadet = {}
 
-Cadet._VERSION = "0.0.0a"
+Cadet._VERSION = "0.0.0b"
 
 -- The default HTTP response.
 Cadet.response = {
@@ -88,7 +91,7 @@ Cadet.status_map = {
 
 -- Writes the given string to the standard output, but with CRLF appended.
 function printcrlf(str)
-  io.write(string.format("%s\r\n", str))
+  httpd.write(string.format("%s\r\n", str))
 end
 
 --[[
@@ -116,7 +119,7 @@ function Cadet.finish()
 
   printcrlf(format("Content-Length: %d", string.len(res.body)))
   printcrlf("")
-  io.write(res.body)
+  httpd.write(res.body)
 end
 
 

--- a/cadet.lua
+++ b/cadet.lua
@@ -99,14 +99,14 @@ end
   thing when calling Cadet.finish(). By default it does nothing. You are
   free to re-implement it.
 ]]
-Cadet.before = function() end
+Cadet.before = function(Cadet) end
 
 -- Writes the entire HTTP response to the standard output.
 function Cadet.finish()
   local res = Cadet.response 
   local format = string.format
 
-  Cadet.before()
+  Cadet.before(Cadet)
 
   printcrlf(format(
     "HTTP/%s %d %s", res.http_version, res.status,
@@ -173,6 +173,13 @@ function Cadet.render_file(template_path, view)
   end
 end
 
+--[[
+  Calls Cadent.render_file then Cadet.write() with the result
+  see Cadet.render_file()).
+]]
+function Cadet.render_file_write(template_path, view)
+  Cadet.write(Cadet.render_file(template_path, view))
+end
 
 --[[
   Appends the given string to the Cadet.response's body.


### PR DESCRIPTION
This pull requests makes the following changes to Cadet:
- Use `httpd.write()` instead of `io.write()` to support TLS (closes issue #1)
- Alter the function signature and invocation of `Cadet.before()` so that a script implementing its own before() function can modify the response.  As an example, this is useful for implementing a [generic error handler](https://github.com/TravisPaul/cadet/tree/master/example/error).
- Add a `Cadet.render_file_write()` convenience method to render and write a template in one go.

I have some other changes in my fork, and in some private repos where I'm experimenting with Cadet but so far these are the clean, well-tested changes that I believe may be desirable upstream.

Let me know what you think,
Travis
